### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=The MAX31855 performs cold-junction compensation and digitizes the sig
 category=Sensors
 url=https://github.com/andygock/MAX31855
 architectures=avr
-includes=
+includes=MAX31855.h


### PR DESCRIPTION
The includes field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > MAX31855**. Leaving this field empty causes that action to add the following line to the sketch:
```
#include <>
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format